### PR TITLE
Creates icon package generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Since Lerna will install a separate instance of LitElement for each package with
 ## Developing
 
 Each package is symlinked within the ia-icons package using Lerna. If you would like to add an icon package to this monorepo, you can start by copying one of the existing icon directories. Next, navigate to ./packages/ia-icons and run `lerna add @internetarchive/icon-${new_icon} --scope=@internetarchive/ia-icons`, where new_icon is your icon package's name. You can then open up ./packages/ia-icons/src/ia-icon.js and import the new icon. Be sure to also add the icon name to index.html so it renders in the demo page.
+
+## Scaffolding a New Icon Package
+
+A Node shell script is provided as bin/bootstrap_icon to make creating a new icon as fast as possible. Copy your SVG icon file to the 'icons' directory and run `bin/bootstrap test.svg icon-name 'icon description'` to generate the necessary files for a new icon package. If you want to inspect the contents of the files that will be written using the supplied arguments, add a final argument 'true' to receive output logged to stdout rather than written to the file system. If no description is provided, a description using the icon name will be created.

--- a/bin/bootstrap_icon
+++ b/bin/bootstrap_icon
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+// Deps
+const fs = require('fs');
+const path = require('path');
+const indexTemplate = require('../scaffold/index.template');
+const packageFileTemplate = require('../scaffold/package.json.template');
+
+// Newline character based on local OS
+const EOL = process.platform === 'win32' ? '\r\n' : '\n';
+
+// Pull variables from command-line arguments. First two are the Node
+// executable path and the path to this file, which are both unused.
+const [_, __, svgFileName, packageName, descriptiveName, dryRun] = process.argv;
+
+if (!svgFileName) {
+  exitWith('No SVG file name given.', 9);
+}
+if (!packageName) {
+  exitWith(`No package name given. A package name must be given.${EOL}The name given acts as a suffix to the full package name, e.g. an argument of "advance" creates a package named "icon-advance".`);
+}
+
+// Read in local SVG file as string
+const svgPath = path.join(__dirname, '..', 'icons', svgFileName);
+
+if (!fs.existsSync(svgPath)) {
+  exitWith(`The SVG file does not exist at path ${svgPath}. Please correct your file name or move your icon to this path`, 9);
+}
+
+const svgString = fs.readFileSync(svgPath, 'utf8').replace(new RegExp(`${EOL}$`), '');
+const packageDir = path.join(__dirname, '..', 'packages', `icon-${packageName}`);
+
+if (fs.existsSync(packageDir)) {
+  return exitWith(`Package icon-${packageName} already exists. Please choose a different name.`, 1);
+}
+
+const indexContents = indexTemplate(svgString);
+const packageContents = packageFileTemplate(packageName, descriptiveName || packageName);
+
+if (dryRun) {
+  console.log('============index.js============');
+  console.log(indexTemplate(svgString));
+  console.log('==========package.json==========');
+  console.log(packageFileTemplate(packageName, descriptiveName || packageName));
+  process.exit(0);
+}
+
+fs.mkdirSync(packageDir);
+fs.writeFileSync(path.join(packageDir, 'index.js'), indexContents);
+fs.writeFileSync(path.join(packageDir, 'package.json'), packageContents);
+fs.copyFileSync(path.join(__dirname, '..', 'scaffold', 'index.d.ts'), path.join(packageDir, 'index.d.ts'));
+
+exitWith(`Package icon-${packageName} created. Navigate to ${packageDir} and run 'npm i' to generate a lock file and install dependencies.`, 0);
+
+function exitWith(message, code) {
+  console.log(message);
+  process.exit(code);
+}

--- a/bin/bootstrap_icon
+++ b/bin/bootstrap_icon
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const indexTemplate = require('../scaffold/index.template');
 const packageFileTemplate = require('../scaffold/package.json.template');
+const componentFileTemplate = require('../scaffold/component.template');
 
 // Newline character based on local OS
 const EOL = process.platform === 'win32' ? '\r\n' : '\n';
@@ -36,18 +37,22 @@ if (fs.existsSync(packageDir)) {
 
 const indexContents = indexTemplate(svgString);
 const packageContents = packageFileTemplate(packageName, descriptiveName || packageName);
+const componentContents = componentFileTemplate(packageName);
 
 if (dryRun) {
   console.log('============index.js============');
-  console.log(indexTemplate(svgString));
+  console.log(indexContents);
   console.log('==========package.json==========');
-  console.log(packageFileTemplate(packageName, descriptiveName || packageName));
+  console.log(packageContents);
+  console.log(`========icon-${packageName}.js========`);
+  console.log(componentContents);
   process.exit(0);
 }
 
 fs.mkdirSync(packageDir);
 fs.writeFileSync(path.join(packageDir, 'index.js'), indexContents);
 fs.writeFileSync(path.join(packageDir, 'package.json'), packageContents);
+fs.writeFileSync(path.join(packageDir, `icon-${packageName}.js`), componentContents);
 fs.copyFileSync(path.join(__dirname, '..', 'scaffold', 'index.d.ts'), path.join(packageDir, 'index.d.ts'));
 
 exitWith(`Package icon-${packageName} created. Navigate to ${packageDir} and run 'npm i' to generate a lock file and install dependencies.`, 0);

--- a/icons/test.svg
+++ b/icons/test.svg
@@ -1,0 +1,24 @@
+<svg
+  viewBox="0 0 21 19"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-labelledby="advanceTitleID advanceDescID"
+>
+  <title id="advanceTitleID">Advance icon</title>
+  <desc id="advanceDescID">An arrow pointing in a forward direction</desc>
+  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g transform="translate(-200.000000, -15.000000)">
+      <g transform="translate(56.922243, 5.000000)">
+        <g transform="translate(144.000000, 10.000000)">
+          <g transform="translate(11.000000, 10.000000) scale(-1, 1) translate(-11.000000, -10.000000) translate(1.000000, 0.000000)">
+            <polyline class="stroke-color" stroke-width="2" stroke-linejoin="round" points="14.4444444 16.6666667 20 16.6666667 20 3.33333333 5.55555556 3.33333333"></polyline>
+            <polygon class="fill-color" points="5.55555556 0 5.55555556 6.66666667 1.11111111 3.33333333"></polygon>
+            <text transform="translate(6.666667, 13.333333) scale(-1, 1) translate(-6.666667, -13.333333) " font-family="HelveticaNeue, Helvetica Neue" font-size="10" font-weight="normal" class="fill-color">
+              <tspan x="0" y="17.3333333">10</tspan>
+            </text>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/scaffold/component.template.js
+++ b/scaffold/component.template.js
@@ -1,0 +1,32 @@
+module.exports = (iconName) => {
+  const className = `${iconName.substr(0, 1).toUpperCase()}${iconName.substr(1)}`;
+
+  return `import icon from './index.js';
+
+class IAIcon${className} extends LitElement {
+  static get styles() {
+    return css\`
+      :host {
+        width: var(--iconWidth, 'auto');
+        height: var(--iconHeight, 'auto');
+      }
+
+      .fill-color {
+        fill: var(--iconFillColor);
+      }
+
+      .stroke-color {
+        stroke: var(--iconStrokeColor);
+      }
+    \`;
+  }
+
+  render() {
+    return icon;
+  }
+}
+
+customElements.define('ia-icon-${iconName}', IAIcon${className});
+
+export default IAIcon;`;
+};

--- a/scaffold/index.d.ts
+++ b/scaffold/index.d.ts
@@ -1,0 +1,3 @@
+import { TemplateResult } from 'lit-html';
+declare const icon: TemplateResult;
+export default icon;

--- a/scaffold/index.template.js
+++ b/scaffold/index.template.js
@@ -1,0 +1,6 @@
+module.exports = (svg) => `import { html } from 'lit-html';
+
+export default html\`
+${svg}
+\`;
+`;

--- a/scaffold/package.json.template.js
+++ b/scaffold/package.json.template.js
@@ -1,0 +1,42 @@
+module.exports = (packageName, descriptiveName) => `{
+  "name": "@internetarchive/icon-${packageName}",
+  "version": "0.4.0",
+  "description": "SVG ${descriptiveName} icon",
+  "license": "AGPL-3.0-only",
+  "main": "index.js",
+  "module": "index.js",
+  "types": "index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "lit-html": "^1.2.1"
+  },
+  "devDependencies": {
+    "@open-wc/eslint-config": "^1.0.0",
+    "eslint": "^6.1.0",
+    "eslint-plugin-lit": "^0.5.0",
+    "husky": "^4.2.3",
+    "lint-staged": "^8.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "@open-wc/eslint-config"
+    ]
+  }
+}
+`;


### PR DESCRIPTION
This creates a shell script and scaffolding files to automate the creation of new icon packages. With the script, you can copy your SVG file to the 'icons' directory, run the script with two or three arguments, and the required package files will be generated. As an example, you can run `bin/bootstrap_icon test.svg test 'test generation'` to generate the necessary files for a new icon package in 'packages/icon-test'. Details are in the readme, including instructions on how to perform a dry run.