### PR TITLE
Adds dimensions css variables to <ia-icon> package

### DIFF
--- a/packages/ia-icons/README.md
+++ b/packages/ia-icons/README.md
@@ -14,6 +14,8 @@ import { IAIcon } from './src/ia-icon';
 ia-icon {
   --iconFillColor: #0066cc;
   --iconStrokeColor: #ffffff;
+  --iconWidth: 40px;
+  --iconHeight: 40px;
 }
 ```
 
@@ -34,3 +36,10 @@ Run the tests with `yarn test`.
 * /src/ia-icons.js - Class definitions for each LitElement
 * /src/icons - Place icon SVGs here. Convention is to export a Lit-html template
 * /test - unit tests
+
+## Single Icons
+
+This package is part of [a monorepo](https://github.com/internetarchive/iaux-icons)
+that includes a published package for each icon included here. Each package
+includes a raw SVG file, a LitHtml template literal, and a defined custom
+element created with LitElement.

--- a/packages/ia-icons/index.html
+++ b/packages/ia-icons/index.html
@@ -10,22 +10,28 @@
       html {
         font: normal 10px 'Helvetica Neue', Helvetica, Arial, sans-serif;
         font-size: 10px;
+        --iconWidth: 40px;
+        --iconHeight: 40px;
       }
       body {
         margin: 0;
-        padding: 0;
+        padding: 0 2rem;
+      }
+
+      h3 {
+        font-size: 2rem;
       }
 
       ul {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(92px, 1fr));
+        grid-gap: 1rem;
+        padding: 0;
+        list-style: none;
       }
 
       li {
-        display: grid;
-        grid-template: 1fr auto / 1fr;
-        padding: 1.5rem 2.4rem;
-        margin: .5rem;
+        padding: 1.5rem 0;
         border: 2px solid #ccc;
         text-align: center;
       }
@@ -37,11 +43,6 @@
 
       p {
         margin: 0;
-        white-space: nowrap;
-      }
-
-      ia-icon {
-        width: 40px;
       }
 
       icon-donate {

--- a/packages/ia-icons/src/ia-icon.js
+++ b/packages/ia-icons/src/ia-icon.js
@@ -82,6 +82,11 @@ class IAIcon extends LitElement {
 
   static get styles() {
     return css`
+      svg {
+        width: var(--iconWidth, 'auto');
+        height: var(--iconHeight, 'auto');
+      }
+
       .fill-color {
         fill: var(--iconFillColor);
       }


### PR DESCRIPTION
I've been adding `--iconWidth` and `--iconHeight` everywhere thinking I had already added the variables to ia-icon, but it must have gotten lost in the package generation commits. This adds the two CSS variables as well as spruces up the demo page to be more evenly spaced.

![ia-icons](https://user-images.githubusercontent.com/39553/91636958-ab9fc500-e9d2-11ea-914e-60165c59f8c9.gif)
