### PR TITLE
Remove width/height attributes from close-circle svg to allow resizing

### DIFF
--- a/icons/close-circle.svg
+++ b/icons/close-circle.svg
@@ -1,4 +1,4 @@
-<svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg" aria-labelledby="closeCircleTitleID closeCircleDescID">
+<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" aria-labelledby="closeCircleTitleID closeCircleDescID">
   <title id="closeCircleTitleID">Close circle icon</title>
   <desc id="closeCircleDescID">A line drawing of an X in a circle</desc>
   <path

--- a/packages/icon-close-circle/close-circle.svg
+++ b/packages/icon-close-circle/close-circle.svg
@@ -1,4 +1,4 @@
-<svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg" aria-labelledby="closeCircleTitleID closeCircleDescID">
+<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" aria-labelledby="closeCircleTitleID closeCircleDescID">
   <title id="closeCircleTitleID">Close circle icon</title>
   <desc id="closeCircleDescID">A line drawing of an X in a circle</desc>
   <path

--- a/packages/icon-close-circle/index.js
+++ b/packages/icon-close-circle/index.js
@@ -2,9 +2,7 @@ import { html } from 'lit';
 
 export default html`
   <svg
-    height="12"
     viewBox="0 0 12 12"
-    width="12"
     xmlns="http://www.w3.org/2000/svg"
     aria-labelledby="closeCircleTitleID closeCircleDescID"
   >


### PR DESCRIPTION
The width/height attributes on the close-circle svg prevent all modifications to the icon's size, forcing it to always be 12x12. This makes the CSS size vars useless.

This PR removes the hardcoded width/height to provide flexibility in determining the appropriate size of the icon.