### PR TITLE
Restore lit dep on 43 icons and fix scaffold root cause

### DIFF
--- a/packages/icon-advance/package-lock.json
+++ b/packages/icon-advance/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-advance",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-advance",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-advance/package.json
+++ b/packages/icon-advance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-advance",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG advance icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-applepay/package-lock.json
+++ b/packages/icon-applepay/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-applepay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-applepay",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-applepay/package.json
+++ b/packages/icon-applepay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-applepay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG applepay icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-audio/package-lock.json
+++ b/packages/icon-audio/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-audio",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-audio",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-audio/package.json
+++ b/packages/icon-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-audio",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG audio icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-bookmark/package-lock.json
+++ b/packages/icon-bookmark/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-bookmark",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-bookmark",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^2.0.0",
@@ -56,7 +56,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
       "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.11.6",
@@ -1309,6 +1308,21 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/building-utils": {
       "version": "2.18.2",
       "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.2.tgz",
@@ -1570,6 +1584,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
       "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1579,6 +1594,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -1588,6 +1604,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
       "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -1598,7 +1615,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/accepts": {
       "version": "1.3.5",
@@ -2011,6 +2029,12 @@
       "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/whatwg-url": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
@@ -2056,7 +2080,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
       "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2913,7 +2936,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -4213,7 +4235,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4363,7 +4384,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
       "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -6249,7 +6269,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/karma": {
       "version": "4.4.1",
@@ -6979,6 +7000,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-element": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
@@ -6992,7 +7024,28 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
       "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
+      "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/lit/node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit/node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/load-json-file": {
       "version": "2.0.0",
@@ -7038,7 +7091,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7808,6 +7862,7 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
       "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
@@ -8386,6 +8441,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -8394,7 +8450,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "2.0.0",
@@ -9038,7 +9095,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
       "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9159,6 +9215,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
       "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
@@ -9187,6 +9244,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -9196,6 +9254,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9205,6 +9264,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10936,7 +10996,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
       "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.11.6",
@@ -11972,6 +12031,19 @@
         "vary": "^1.1.2"
       }
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="
+    },
+    "@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "@open-wc/building-utils": {
       "version": "2.18.2",
       "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.2.tgz",
@@ -12206,6 +12278,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
       "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -12215,6 +12288,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -12224,6 +12298,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
       "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -12234,7 +12309,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/accepts": {
       "version": "1.3.5",
@@ -12647,6 +12723,11 @@
       "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
     "@types/whatwg-url": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
@@ -12688,8 +12769,7 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
       "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.1",
@@ -13364,7 +13444,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -14428,7 +14507,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -14568,7 +14646,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
       "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -16002,7 +16079,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "karma": {
       "version": "4.4.1",
@@ -16591,6 +16669,36 @@
         }
       }
     },
+    "lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "requires": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      },
+      "dependencies": {
+        "lit-element": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+          "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+          "requires": {
+            "@lit-labs/ssr-dom-shim": "^1.5.0",
+            "@lit/reactive-element": "^2.1.0",
+            "lit-html": "^3.3.0"
+          }
+        },
+        "lit-html": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+          "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+          "requires": {
+            "@types/trusted-types": "^2.0.2"
+          }
+        }
+      }
+    },
     "lit-element": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
@@ -16603,7 +16711,8 @@
     "lit-html": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
+      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -16643,7 +16752,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -17248,6 +17358,7 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
       "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
@@ -17715,6 +17826,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -17723,7 +17835,8 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -18251,7 +18364,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
       "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fsevents": "~2.1.2"
       }
@@ -18345,6 +18457,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
       "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
@@ -18358,19 +18471,22 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/packages/icon-bookmark/package.json
+++ b/packages/icon-bookmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-bookmark",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Multi-state SVG bookmark icon component",
   "author": "Shane Riley, Internet Archive",
   "license": "AGPL-3.0-only",
@@ -19,7 +19,7 @@
     "test:watch": "karma start --auto-watch=true --single-run=false"
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^2.0.0",

--- a/packages/icon-calendar-blank/package-lock.json
+++ b/packages/icon-calendar-blank/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-calendar-blank",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-calendar-blank",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-calendar-blank/package.json
+++ b/packages/icon-calendar-blank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-calendar-blank",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG calendar-blank icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-calendar/package-lock.json
+++ b/packages/icon-calendar/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-calendar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-calendar",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-calendar/package.json
+++ b/packages/icon-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-calendar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG calendar icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-close-circle/package-lock.json
+++ b/packages/icon-close-circle/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-close-circle",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-close-circle",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -1765,7 +1784,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4238,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-close-circle/package.json
+++ b/packages/icon-close-circle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-close-circle",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "SVG close-circle icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-close/package-lock.json
+++ b/packages/icon-close/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-close",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-close",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-close/package.json
+++ b/packages/icon-close/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-close",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG close icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-collapse-sidebar/package-lock.json
+++ b/packages/icon-collapse-sidebar/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-collapse-sidebar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-collapse-sidebar",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-collapse-sidebar/package.json
+++ b/packages/icon-collapse-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-collapse-sidebar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG collapse-sidebar icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-credit-card/package-lock.json
+++ b/packages/icon-credit-card/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-credit-card",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-credit-card",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-credit-card/package.json
+++ b/packages/icon-credit-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-credit-card",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG credit-card icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-dl/package-lock.json
+++ b/packages/icon-dl/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-dl",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-dl",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-dl/package.json
+++ b/packages/icon-dl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-dl",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG dl icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-donate/package-lock.json
+++ b/packages/icon-donate/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-donate",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-donate",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-donate/package.json
+++ b/packages/icon-donate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-donate",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG donate icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-edit-pencil/package-lock.json
+++ b/packages/icon-edit-pencil/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-edit-pencil",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-edit-pencil",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -1765,7 +1784,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4238,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-edit-pencil/package.json
+++ b/packages/icon-edit-pencil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-edit-pencil",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "SVG edit-pencil icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-ellipses/package-lock.json
+++ b/packages/icon-ellipses/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-ellipses",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-ellipses",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-ellipses/package.json
+++ b/packages/icon-ellipses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-ellipses",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG ellipses icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-email/package-lock.json
+++ b/packages/icon-email/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-email",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-email",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-email/package.json
+++ b/packages/icon-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-email",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG email icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-facebook/package-lock.json
+++ b/packages/icon-facebook/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-facebook",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-facebook",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-facebook/package.json
+++ b/packages/icon-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-facebook",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG facebook icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-googlepay/package-lock.json
+++ b/packages/icon-googlepay/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-googlepay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-googlepay",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-googlepay/package.json
+++ b/packages/icon-googlepay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-googlepay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG googlepay icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-ia-logo/package-lock.json
+++ b/packages/icon-ia-logo/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-ia-logo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-ia-logo",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-ia-logo/package.json
+++ b/packages/icon-ia-logo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-ia-logo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG ia-logo icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-images/package-lock.json
+++ b/packages/icon-images/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-images",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-images",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-images/package.json
+++ b/packages/icon-images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-images",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG images icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-info/package-lock.json
+++ b/packages/icon-info/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-info",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-info",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-info/package.json
+++ b/packages/icon-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-info",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG info icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-link/package-lock.json
+++ b/packages/icon-link/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-link",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-link",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-link/package.json
+++ b/packages/icon-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-link",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG link icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-locale-pin/package-lock.json
+++ b/packages/icon-locale-pin/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-locale-pin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-locale-pin",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-locale-pin/package.json
+++ b/packages/icon-locale-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-locale-pin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG locale-pin icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-lock/package-lock.json
+++ b/packages/icon-lock/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-lock",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-lock",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-lock/package.json
+++ b/packages/icon-lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-lock",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG lock icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-magnify-minus/package-lock.json
+++ b/packages/icon-magnify-minus/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-magnify-minus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-magnify-minus",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-magnify-minus/package.json
+++ b/packages/icon-magnify-minus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-magnify-minus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG magnify-minus icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-magnify-plus/package-lock.json
+++ b/packages/icon-magnify-plus/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-magnify-plus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-magnify-plus",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-magnify-plus/package.json
+++ b/packages/icon-magnify-plus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-magnify-plus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG magnify-plus icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-paypal/package-lock.json
+++ b/packages/icon-paypal/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-paypal",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-paypal",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-paypal/package.json
+++ b/packages/icon-paypal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-paypal",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG paypal icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-pinterest/package-lock.json
+++ b/packages/icon-pinterest/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-pinterest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-pinterest",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-pinterest/package.json
+++ b/packages/icon-pinterest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-pinterest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG pinterest icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-search/package-lock.json
+++ b/packages/icon-search/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-search",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-search",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-search/package.json
+++ b/packages/icon-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-search",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG search icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-share/package-lock.json
+++ b/packages/icon-share/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-share",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-share",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-share/package.json
+++ b/packages/icon-share/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-share",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG share icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-software/package-lock.json
+++ b/packages/icon-software/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-software",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-software",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-software/package.json
+++ b/packages/icon-software/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-software",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG software icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-sort-ascending/package-lock.json
+++ b/packages/icon-sort-ascending/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-sort-ascending",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-sort-ascending",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-sort-ascending/package.json
+++ b/packages/icon-sort-ascending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-sort-ascending",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG sort-ascending icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-sort-descending/package-lock.json
+++ b/packages/icon-sort-descending/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-sort-descending",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-sort-descending",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-sort-descending/package.json
+++ b/packages/icon-sort-descending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-sort-descending",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG sort-descending icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-texts/package-lock.json
+++ b/packages/icon-texts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-texts",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-texts",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-texts/package.json
+++ b/packages/icon-texts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-texts",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG texts icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-toc/package-lock.json
+++ b/packages/icon-toc/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-toc",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-toc",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-toc/package.json
+++ b/packages/icon-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-toc",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG toc icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-tumblr/package-lock.json
+++ b/packages/icon-tumblr/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-tumblr",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-tumblr",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-tumblr/package.json
+++ b/packages/icon-tumblr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-tumblr",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG tumblr icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-twitter/package-lock.json
+++ b/packages/icon-twitter/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-twitter",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-twitter",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-twitter/package.json
+++ b/packages/icon-twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-twitter",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG twitter icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-upload/package-lock.json
+++ b/packages/icon-upload/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-upload",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-upload",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-upload/package.json
+++ b/packages/icon-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-upload",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG upload icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-user/package-lock.json
+++ b/packages/icon-user/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-user",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-user",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-user/package.json
+++ b/packages/icon-user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-user",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG user icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-venmo/package-lock.json
+++ b/packages/icon-venmo/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-venmo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-venmo",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-venmo/package.json
+++ b/packages/icon-venmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-venmo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG venmo icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-video/package-lock.json
+++ b/packages/icon-video/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-video",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-video",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-video/package.json
+++ b/packages/icon-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-video",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG video icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-visual-adjustment/package-lock.json
+++ b/packages/icon-visual-adjustment/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-visual-adjustment",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-visual-adjustment",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-visual-adjustment/package.json
+++ b/packages/icon-visual-adjustment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-visual-adjustment",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG visual-adjustment icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-volumes/package-lock.json
+++ b/packages/icon-volumes/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-volumes",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-volumes",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-volumes/package.json
+++ b/packages/icon-volumes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-volumes",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG volumes icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/packages/icon-web/package-lock.json
+++ b/packages/icon-web/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/icon-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/icon-web",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^1.0.0",
@@ -194,6 +194,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@open-wc/eslint-config": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@open-wc/eslint-config/-/eslint-config-1.3.0.tgz",
@@ -252,13 +267,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1630,7 +1650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -4237,11 +4256,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause"
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/packages/icon-web/package.json
+++ b/packages/icon-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/icon-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SVG web icon",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",

--- a/scaffold/package.json.template.js
+++ b/scaffold/package.json.template.js
@@ -13,7 +13,7 @@ module.exports = (packageName, descriptiveName, version) => `{
     "lint": "eslint ."
   },
   "dependencies": {
-    "lit-html": "^1.2.1"
+    "lit": "^2.0.2 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^1.0.0",


### PR DESCRIPTION
## Summary

- PR #28 accidentally replaced `"lit": "^2.0.2"` with `"lit-html": "^1.2.1"` in the `dependencies` of **43 icon packages** while bumping them to 1.4.0 (stray step in "Re-apply some accidentally dropped custom icon mods + publish").
- Source code was unaffected — `index.js` / `icon-*.js` / `index.d.ts` all still import from `'lit'`. Only the declared dep in `package.json` disagreed.
- This PR restores `"lit": "^2.0.2 || ^3.0.0"` on all 43 regressed packages, bumps their versions, **and fixes the scaffold that caused the regression in the first place**.

## Scope

All 43 icons pushed to Lit 1 by #28, now pushed back to `lit`:

- **41 packages bump 1.4.0 → 1.4.1**: icon-advance, icon-applepay, icon-audio, icon-bookmark, icon-calendar, icon-calendar-blank, icon-close, icon-collapse-sidebar, icon-credit-card, icon-dl, icon-donate, icon-ellipses, icon-email, icon-facebook, icon-googlepay, icon-ia-logo, icon-images, icon-info, icon-link, icon-locale-pin, icon-lock, icon-magnify-minus, icon-magnify-plus, icon-paypal, icon-pinterest, icon-search, icon-share, icon-software, icon-sort-ascending, icon-sort-descending, icon-texts, icon-toc, icon-tumblr, icon-twitter, icon-upload, icon-user, icon-venmo, icon-video, icon-visual-adjustment, icon-volumes, icon-web
- **2 packages bump 1.4.1 → 1.4.2**: icon-close-circle, icon-edit-pencil (already re-published once post-#28)

`@internetarchive/ia-icons` was not regressed by #28 (stayed on `lit: ^2.8.0`) and isn't touched here.

## Scaffold fix (root cause)

`scaffold/package.json.template.js` declared `"lit-html": "^1.2.1"` even though `scaffold/component.template.js` and `scaffold/index.template.js` both already imported from the `lit` umbrella package. **This is what caused PR #28** — running `bin/bootstrap_icon` (or bulk via `bin/generate_all`) overwrote each package's `lit` dep with the broken `lit-html@^1.x` declaration.

Fix: one-line change to the scaffold dependency declaration to match what the shipped icons now use (`"lit": "^2.0.2 || ^3.0.0"`). Verified by invoking the template directly:

```bash
node -e "console.log(require('./scaffold/package.json.template')('close','close','1.4.1'))"
```

→ generated `package.json` dependencies block is byte-identical to `packages/icon-close/package.json`. Without this fix, the next regen would silently reintroduce the regression.

## Why `^2.0.2 || ^3.0.0`

Caret `^2` alone rejects Lit 3, which would force Lit 3 consumers to install Lit 2 alongside and re-create the dual-Lit problem we're trying to avoid. The dual range lets npm pick whichever major is already in the consumer's tree and keep it single. Matches the pattern `@internetarchive/modal-manager@2.0.5` already uses.

## What actually changes

- 43 `packages/*/package.json`: `version` patch bump + `dependencies.lit-html: ^1.2.1` → `dependencies.lit: ^2.0.2 || ^3.0.0`.
- 43 `packages/*/package-lock.json`: regenerated via `npm install` inside each dir. Production dep resolution is now Lit 3 single-tree (`lit-element@^4.2.0`, `lit-html@^3.3.0`, `@lit/reactive-element@^2.1.0`).
- 1 `scaffold/package.json.template.js`: dependency declaration updated to `lit: ^2.0.2 || ^3.0.0`.

Some lock files still contain `"lit-html": "^1.0.0"` entries, **all under devDependency chains** (`@open-wc/testing-karma`, `@open-wc/scoped-elements`, old `lit-element@^2.x`). These don't affect what `npm publish` ships to consumers — only the icon's own local dev / test environment. Cleaning them up would mean modernizing the test tooling, which is out of scope here.

## Commits

- `c088ed7` — initial fix on icon-close + icon-user (the two blocking offshoot via ia-book-actions / modal-manager)
- `9ce27a2` — sweep covering the remaining 41 icons
- `a24136d` — scaffold fix (root cause) so future regens don't reintroduce the regression

## Tracking

- Internet Archive WEBDEV-8365 (icon-close), WEBDEV-8366 (icon-user), WEBDEV-8367 (modal-manager — auto-resolves via existing `^1.4.0` caret), WEBDEV-8368 (the 41-icon sweep), **WEBDEV-8372 (this PR's scaffold fix)**; umbrella WEBDEV-8364.
- Regression commit: 199e0a0 / #28.

## Test plan

- [x] `grep '"lit-html": "\^1' packages/*/package.json` returns nothing (production deps clean across all 43)
- [x] Source files unchanged — every icon still imports from `'lit'`
- [x] Lock files regenerate without hard failures; production Lit tree resolves to Lit 3
- [x] Scaffold dry-run output matches `packages/icon-close/package.json` dependencies block byte-for-byte
- [ ] Reviewer: spot-check a handful of icons render correctly (no visual regression; source wasn't changed but a fresh install sanity check is cheap)
- [ ] Post-merge: bulk publish to npm — Lerna publish or equivalent, since 43 packages need new versions out. Prefer publishing all together so consumers that depend on `ia-icons` meta-package don't flap during rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)